### PR TITLE
Change login name to PokePrizeCheck

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PokéCheck</title>
+    <title>PokéPrizeCheck</title>
     <meta name="description" content="A Pokémon TCG Prize Card Predictor" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="author" content="Lovable" />

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -26,10 +26,10 @@ const Login = () => {
         {/* Header Section */}
         <div className="text-center mb-8 space-y-2">
           <div className="flex items-center justify-center gap-2">
-            <h1 className="text-4xl font-bold text-foreground">PokéCheck</h1>
+            <h1 className="text-4xl font-bold text-foreground">PokéPrizeCheck</h1>
             <img 
               src="/lovable-uploads/b410b0a7-6855-417f-b3bc-d57790375de7.png" 
-              alt="PokéCheck Logo" 
+              alt="PokéPrizeCheck Logo" 
               className="w-8 h-8" 
             />
           </div>


### PR DESCRIPTION
Updated the login header to reflect the new name "PokePrizeCheck" with a tilde above the 'e' in "Poke". [skip gpt_engineer]