### PR TITLE
Set default page to dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import Index from "@/pages/Index";
@@ -19,7 +19,7 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <Router>
         <Routes>
-          <Route path="/" element={<Index />} />
+          <Route path="/" element={<Navigate to="/decks" replace />} />
           <Route path="/login" element={<Login />} />
           <Route path="/decks" element={<DeckList />} />
           <Route path="/decks/:id" element={<DeckPreview />} />


### PR DESCRIPTION
Updated the routing configuration to set the default page to the dashboard/decks page instead of the index page. [skip gpt_engineer]